### PR TITLE
Fix imports in init.js

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,4 +1,4 @@
-import { setGlobalInternal, getGlobalInternal, addCallback } from 'reactn';
+import { setGlobal as setGlobalInternal, getGlobal as getGlobalInternal, addCallback } from 'reactn';
 import { debounce } from './helpers';
 
 const defaults = {


### PR DESCRIPTION
Hello!

After attempting to use this library, and setting things up with:

```
initReactnPersist({
  storage: localStorage,
  whitelist: ["redacted", "redacted_2"],
  key: "@reactn",
});
```

I noticed that no `@reactn` key was not being set in my local storage.

So I enabled the debug option:
```
initReactnPersist({
  storage: localStorage,
  debug: true,
  whitelist: ["redacted", "redacted_2"],
  key: "@reactn",
});
```

And the console spit out:

`reactn-persist:  init Object { error: "setGlobal is not a function" }`

So a little debugging later:

```
const rehidrate = async ({ storage, key, initialValue, whitelist, debug, provider }) => {
	const getGlobal = !!provider ? provider.getGlobal : getGlobalInternal;
	const setGlobal = !!provider ? provider.setGlobal : setGlobalInternal;

	console.log('-->', getGlobal, setGlobal);
        ...
```

Produced:

`--> undefined undefined`

So it appears that when you don't explicitly set the reactn provider the package doesn't work because `setGlobalInternal`, and `getGlobalInternal` in the import statement do not exist.

By changing:

```
import { setGlobalInternal, getGlobalInternal, addCallback } from 'reactn';
```

to

```
import { setGlobal as setGlobalInternal, getGlobal as getGlobalInternal, addCallback } from 'reactn';
```

The package works as expected, and I see the `@reactn` key value pair show up in my local storage.